### PR TITLE
feat: allow to use NestJS method decorators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,9 +1729,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -4247,9 +4247,9 @@
             }
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"

--- a/templates/nestjs-grpc.hbs
+++ b/templates/nestjs-grpc.hbs
@@ -42,9 +42,17 @@ export interface {{@key}} {
     {{comment}}
 {{/if}}
     {{#if this.requestStream}}
-    {{uncapitalize @key}}(data: Observable<{{this.requestType}}>, metadata?: Metadata): Observable<{{this.responseType}}>;
+    {{uncapitalize @key}}(
+        data: Observable<{{this.requestType}}>,
+        metadata?: Metadata,
+        ...rest: any[]
+    ): Observable<{{this.responseType}}>;
     {{else}}
-    {{uncapitalize @key}}(data: {{this.requestType}}, metadata?: Metadata): Observable<{{this.responseType}}>;
+    {{uncapitalize @key}}(
+        data: {{this.requestType}},
+        metadata?: Metadata,
+        ...rest: any[]
+    ): Observable<{{this.responseType}}>;
     {{/if}}
 {{/each}}
 }

--- a/test/multipackage.ts
+++ b/test/multipackage.ts
@@ -11,7 +11,11 @@ export namespace multipackage {
         export interface Multipackage {
             // Test comment
         // Test comment
-            multipackageRpc(data: MultipackageRequest, metadata?: Metadata): Observable<MultipackageResponse>;
+            multipackageRpc(
+                data: MultipackageRequest,
+                metadata?: Metadata,
+                ...rest: any[]
+            ): Observable<MultipackageResponse>;
         }
         // Test comment
         export interface MultipackageRequest {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
This PR allow to use NestJS param decorators, like this:
```typescript
...
import { hero } from 'hero-proto/hero';

type HeroById = hero.HeroById;

@Controller()
export class HeroesController implements hero.HeroesService {
  @GrpcMethod('HeroesService', 'FindOne')
  findOne(
    data: HeroById,
    meta: Metadata,
    @User() user: UserEntity
  ): Observable<hero.Hero> {
    const items = [
      { id: 1, name: 'John' },
      { id: 2, name: 'Doe' },
    ];

    return items.find(({ id }) => id === data.id);
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information